### PR TITLE
Bug fix bundler

### DIFF
--- a/packages/local-client/src/components/Cell-list.tsx
+++ b/packages/local-client/src/components/Cell-list.tsx
@@ -5,6 +5,7 @@ import { useActions } from '../hooks/useActions';
 import { Fragment } from 'react';
 import AddCell from './Add-cell';
 import CellListItem from './Cell-list-item';
+import { setupBundler } from '../bundler';
 
 const CellList: React.FC = () => {
     
@@ -16,6 +17,7 @@ const CellList: React.FC = () => {
     useEffect(() => {  
       if(!fetchRef.current) {
         fetchCells();
+        setupBundler();
         fetchRef.current = true;
       }
     }, [fetchCells]);

--- a/packages/local-client/src/components/Code-cell.tsx
+++ b/packages/local-client/src/components/Code-cell.tsx
@@ -33,7 +33,7 @@ const CodeCell: React.FC<CodeCellProps> = ({ cell }) => {
         return () => {
             clearTimeout(timer);
         }
-    }, [ cell.id, cumulativeCode, createBundle ]);
+    }, [ cell.id, cumulativeCode, createBundle]);
 
     return (
         <Resizable direction='vertical'>


### PR DESCRIPTION
Solution to the problem of multiple initializations of esbuild in bundler.ts.  Creates separate promise as `bundlerSetup` to resolve initialize and to prevent repeat.  This setup function is then called once in cell list, thereby preventing multiple initializes and subsequent errors.   -> https://kristiansigston.medium.com/initializing-esbuild-wasm-84a26b405f12